### PR TITLE
fix name of GitHub Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Spectral Scan is a single self-contained binary, that's easy to get and use. Thi
 Include this Action as a step in your workflow:
 
 ```
-uses: spectral/spectral-action@v3
+uses: spectralops/spectral-github-action@v3
 with:
   spectral-dsn: $SPECTRAL_DSN
   spectral-args: scan --ok


### PR DESCRIPTION
When using `spectral/spectral-action@v3` I got the following error:

> Error: Unable to resolve action `spectral/spectral-action@v3`, repository not found

That's why I changed it to `spectralops/spectral-github-action`.