### PR TITLE
Set SPECTRAL_DSN environment from JS instead of end-user workflow file

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,9 +3,6 @@ name: CI on branch
 # Controls when the workflow will run
 on: [push, workflow_dispatch, pull_request]
 
-env:
-  SPECTRAL_DSN: ${{ secrets.SPECTRAL_DSN }}
-
 jobs:
   ubuntu-ci:
     name: Spectral ubuntu CI
@@ -15,7 +12,7 @@ jobs:
       - name: Install and run Spectral CI
         uses: ./
         with:
-          spectral-dsn: ${{ env.SPECTRAL_DSN }}
+          spectral-dsn: ${{ secrets.SPECTRAL_DSN }}
           spectral-args: scan --ok
   ubuntu-audit:
     name: Spectral ubuntu audit
@@ -25,7 +22,7 @@ jobs:
       - name: Install and run Spectral Audit
         uses: ./
         with:
-          spectral-dsn: ${{ env.SPECTRAL_DSN }}
+          spectral-dsn: ${{ secrets.SPECTRAL_DSN }}
           spectral-args: github -k repo -t ${{ secrets.MY_GITHUB_TOKEN }} https://github.com/SpectralOps/spectral-github-action --include-tags base,audit --ok
   macos-ci:
     name: Spectral macos CI
@@ -35,7 +32,7 @@ jobs:
       - name: Install and run Spectral CI
         uses: ./
         with:
-          spectral-dsn: ${{ env.SPECTRAL_DSN }}
+          spectral-dsn: ${{ secrets.SPECTRAL_DSN }}
           spectral-args: scan --ok
   macos-audit:
     name: Spectral macos audit
@@ -45,7 +42,7 @@ jobs:
       - name: Install and run Spectral Audit
         uses: ./
         with:
-          spectral-dsn: ${{ env.SPECTRAL_DSN }}
+          spectral-dsn: ${{ secrets.SPECTRAL_DSN }}
           spectral-args: github -k repo -t ${{ secrets.MY_GITHUB_TOKEN }} https://github.com/SpectralOps/spectral-github-action --include-tags base,audit --ok
   windows-ci:
     name: Spectral windows CI
@@ -55,7 +52,7 @@ jobs:
       - name: Install and run Spectral CI
         uses: ./
         with:
-          spectral-dsn: ${{ env.SPECTRAL_DSN }}
+          spectral-dsn: ${{ secrets.SPECTRAL_DSN }}
           spectral-args: scan --ok
   windows-audit:
     name: Spectral windows audit
@@ -65,5 +62,5 @@ jobs:
       - name: Install and run Spectral Audit
         uses: ./
         with:
-          spectral-dsn: ${{ env.SPECTRAL_DSN }}
+          spectral-dsn: ${{ secrets.SPECTRAL_DSN }}
           spectral-args: github -k repo -t ${{ secrets.MY_GITHUB_TOKEN }} https://github.com/SpectralOps/spectral-github-action --include-tags base,audit --ok

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI on branch
 
 # Controls when the workflow will run
 on: [push, workflow_dispatch, pull_request]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,6 @@ name: CI
 # Controls when the workflow will run
 on: [push, workflow_dispatch]
 
-env:
-  SPECTRAL_DSN: ${{ secrets.SPECTRAL_DSN }}
-
 jobs:
   ubuntu-ci:
     name: Spectral ubuntu CI
@@ -15,7 +12,7 @@ jobs:
       - name: Install and run Spectral CI
         uses: spectralops/spectral-github-action@v3
         with:
-          spectral-dsn: ${{ env.SPECTRAL_DSN }}
+          spectral-dsn: ${{ secrets.SPECTRAL_DSN }}
           spectral-args: scan --ok
   ubuntu-audit:
     name: Spectral ubuntu audit
@@ -25,7 +22,7 @@ jobs:
       - name: Install and run Spectral Audit
         uses: spectralops/spectral-github-action@v3
         with:
-          spectral-dsn: ${{ env.SPECTRAL_DSN }}
+          spectral-dsn: ${{ secrets.SPECTRAL_DSN }}
           spectral-args: github -k repo -t ${{ secrets.MY_GITHUB_TOKEN }} https://github.com/SpectralOps/spectral-github-action --include-tags base,audit --ok
   macos-ci:
     name: Spectral macos CI
@@ -35,7 +32,7 @@ jobs:
       - name: Install and run Spectral CI
         uses: spectralops/spectral-github-action@v3
         with:
-          spectral-dsn: ${{ env.SPECTRAL_DSN }}
+          spectral-dsn: ${{ secrets.SPECTRAL_DSN }}
           spectral-args: scan --ok
   macos-audit:
     name: Spectral macos audit
@@ -45,7 +42,7 @@ jobs:
       - name: Install and run Spectral Audit
         uses: spectralops/spectral-github-action@v3
         with:
-          spectral-dsn: ${{ env.SPECTRAL_DSN }}
+          spectral-dsn: ${{ secrets.SPECTRAL_DSN }}
           spectral-args: github -k repo -t ${{ secrets.MY_GITHUB_TOKEN }} https://github.com/SpectralOps/spectral-github-action --include-tags base,audit --ok
   windows-ci:
     name: Spectral windows CI
@@ -55,7 +52,7 @@ jobs:
       - name: Install and run Spectral CI
         uses: spectralops/spectral-github-action@v3
         with:
-          spectral-dsn: ${{ env.SPECTRAL_DSN }}
+          spectral-dsn: ${{ secrets.SPECTRAL_DSN }}
           spectral-args: scan --ok
   windows-audit:
     name: Spectral windows audit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI (example)
 
 # Controls when the workflow will run
 on: [push, workflow_dispatch]
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install and run Spectral CI
-        uses: spectralops/spectral-github-action@v3
+        uses: spectralops/spectral-github-action@v4
         with:
           spectral-dsn: ${{ secrets.SPECTRAL_DSN }}
           spectral-args: scan --ok
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install and run Spectral Audit
-        uses: spectralops/spectral-github-action@v3
+        uses: spectralops/spectral-github-action@v4
         with:
           spectral-dsn: ${{ secrets.SPECTRAL_DSN }}
           spectral-args: github -k repo -t ${{ secrets.MY_GITHUB_TOKEN }} https://github.com/SpectralOps/spectral-github-action --include-tags base,audit --ok
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install and run Spectral CI
-        uses: spectralops/spectral-github-action@v3
+        uses: spectralops/spectral-github-action@v4
         with:
           spectral-dsn: ${{ secrets.SPECTRAL_DSN }}
           spectral-args: scan --ok
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install and run Spectral Audit
-        uses: spectralops/spectral-github-action@v3
+        uses: spectralops/spectral-github-action@v4
         with:
           spectral-dsn: ${{ secrets.SPECTRAL_DSN }}
           spectral-args: github -k repo -t ${{ secrets.MY_GITHUB_TOKEN }} https://github.com/SpectralOps/spectral-github-action --include-tags base,audit --ok
@@ -50,7 +50,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install and run Spectral CI
-        uses: spectralops/spectral-github-action@v3
+        uses: spectralops/spectral-github-action@v4
         with:
           spectral-dsn: ${{ secrets.SPECTRAL_DSN }}
           spectral-args: scan --ok
@@ -60,7 +60,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install and run Spectral Audit
-        uses: spectralops/spectral-github-action@v3
+        uses: spectralops/spectral-github-action@v4
         with:
           spectral-dsn: ${{ env.SPECTRAL_DSN }}
           spectral-args: github -k repo -t ${{ secrets.MY_GITHUB_TOKEN }} https://github.com/SpectralOps/spectral-github-action --include-tags base,audit --ok

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Spectral Scan is a single self-contained binary, that's easy to get and use. Thi
 Include this Action as a step in your workflow:
 
 ```
-uses: spectralops/spectral-github-action@v3
+uses: spectralops/spectral-github-action@v4
 with:
   spectral-dsn: $SPECTRAL_DSN
   spectral-args: scan --ok
@@ -45,7 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install and run Spectral CI
-        uses: spectralops/spectral-github-action@v3
+        uses: spectralops/spectral-github-action@v4
         with:
           spectral-dsn: ${{ secrets.SPECTRAL_DSN }}
           spectral-args: scan --ok
@@ -64,7 +64,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install and run Spectral Audit
-        uses: spectralops/spectral-github-action@v3
+        uses: spectralops/spectral-github-action@v4
         with:
           spectral-dsn: ${{ secrets.SPECTRAL_DSN }}
           spectral-args: github -k repo -t ${{ secrets.MY_GITHUB_TOKEN }} https://github.com/SpectralOps/spectral-github-action --include-tags base,audit --ok

--- a/README.md
+++ b/README.md
@@ -32,15 +32,12 @@ You can see an example of this Action [here](https://github.com/SpectralOps/spec
 
 ## Configuration
 
-You'll need to provide Spectral dsn. You can do so via the `SPECTRAL_DSN` environment variable. In the below example, the Spectral dsn is retrieved from [GitHub secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets).
+You'll need to provide Spectral DSN as an input variable. You should always store your DSN in a secure way, like below in [GitHub secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets).
 
 ```yaml
 name: Spectral
 
 on: [push]
-
-env:
-  SPECTRAL_DSN: ${{ secrets.SPECTRAL_DSN }}
 
 jobs:
   scan:
@@ -50,7 +47,7 @@ jobs:
       - name: Install and run Spectral CI
         uses: spectralops/spectral-github-action@v3
         with:
-          spectral-dsn: ${{ env.SPECTRAL_DSN }}
+          spectral-dsn: ${{ secrets.SPECTRAL_DSN }}
           spectral-args: scan --ok
 ```
 
@@ -61,9 +58,6 @@ name: Spectral
 
 on: [push]
 
-env:
-  SPECTRAL_DSN: ${{ secrets.SPECTRAL_DSN }}
-
 jobs:
   scan:
     runs-on: ubuntu-latest
@@ -72,7 +66,7 @@ jobs:
       - name: Install and run Spectral Audit
         uses: spectralops/spectral-github-action@v3
         with:
-          spectral-dsn: ${{ env.SPECTRAL_DSN }}
+          spectral-dsn: ${{ secrets.SPECTRAL_DSN }}
           spectral-args: github -k repo -t ${{ secrets.MY_GITHUB_TOKEN }} https://github.com/SpectralOps/spectral-github-action --include-tags base,audit --ok
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ jobs:
           spectral-args: scan --ok
 ```
 
-Spectral provides another scan option to audit your Github/Gitlab organizaion, user or repo.
+Spectral provides another scan option to audit your Github/Gitlab organization, user or repo.
 
 ```yaml
 name: Spectral

--- a/index.js
+++ b/index.js
@@ -7,6 +7,9 @@ const workspace = process.env.GITHUB_WORKSPACE;
 const spectralDsn = core.getInput('spectral-dsn')
 const binDir = `${workspace}/bin`;
 
+// Provide SPECTRAL_DSN to spectral binary through env
+core.exportVariable('SPECTRAL_DSN', spectralDsn);
+
 main().catch(error => {
     core.setFailed(error)
 })


### PR DESCRIPTION
The action originally suggests that the user should first set _SPECTRAL_DSN_ from GitHub Secrets, then pass this environment variable as an input to the action.

```yaml
...
env:
  SPECTRAL_DSN: ${{ secrets.SPECTRAL_DSN }}
...
        uses: spectralops/spectral-github-action@v3
        with:
          spectral-dsn: ${{ env.SPECTRAL_DSN }}
```

If the user skips configuring the environment variable in their workflow file, and passes the input directly to the action, the installation will succeed because it [uses](https://github.com/SpectralOps/spectral-github-action/blob/5c8cb41967055b3ab87654743d1f2e9851462754/index.js#L34) the value read from `inputs.spectral-dsn` [here](https://github.com/SpectralOps/spectral-github-action/blob/5c8cb41967055b3ab87654743d1f2e9851462754/index.js#L7). 

The execution of the scan itself does not use the same value, and depends on _SPECTRAL_DSN_ being set as an environment variable. Because of this, the scan fails in this scenario: 

```
🙅‍ error: You need to provide your key (Spectral DSN).
```

**This PR** 
- changes the action to set _SPECTRAL_DSN_ from the input variable in index.js 
- updates examples in README.md 
- updates example action 

It removes the need for the user to provide SPECTRAL_DSN **both** as an input to the action and as an environment variable.
